### PR TITLE
Read arguments from a file if command line shortner is enabled

### DIFF
--- a/src/shared/src/main/scala/zio/intellij/testsupport/ZTestRunner.scala
+++ b/src/shared/src/main/scala/zio/intellij/testsupport/ZTestRunner.scala
@@ -9,13 +9,28 @@ object ZTestRunner {
     def toTestArgs: TestArgs = TestArgs(testMethods, Nil, None)
   }
   object Args {
+    /**
+     * Need to read args from file if command line shortener is enabled.
+     *
+     * https://blog.jetbrains.com/idea/2017/10/intellij-idea-2017-3-eap-configurable-command-line-shortener-and-more/
+     */
+    def readArgsFromFileIfCommandLineShortenerIsEnabled(args: Array[String]): Option[Array[String]] = {
+      if (args.length == 1 && args.head.startsWith("@")) {
+        val f = scala.io.Source.fromFile(args.head.drop(1))
+        try Some(f.getLines().toArray) finally f.close()
+      } else {
+        None
+      }
+    }
+
     def parse(args: Array[String]): Args = {
       // Command line arguments from IntelliJ. Can be either regular-style args:
       // [-s testClassName ...] [-t testMethodName ...]
       // or new-style args file (passed via @filename). TODO
 
       // TODO: Add a proper command-line parser
-      val parsedArgs = args
+      val parsedArgs = readArgsFromFileIfCommandLineShortenerIsEnabled(args)
+        .getOrElse(args)
         .sliding(2, 2)
         .collect {
           case Array("-s", term) => ("testClassTerm", term)

--- a/src/shared/test/scala/zio/intellij/testsupport/ZTestRunnerSpec.scala
+++ b/src/shared/test/scala/zio/intellij/testsupport/ZTestRunnerSpec.scala
@@ -1,0 +1,37 @@
+package zio.intellij.testsupport
+
+import java.io.File
+
+import zio.test.Assertion._
+import zio.test._
+import zio.{Has, UIO, ZIO, ZLayer, ZManaged}
+
+object ZTestRunnerSpec extends DefaultRunnableSpec {
+
+  private def tempArgFile: ZLayer[Any, Throwable, Has[File]] = ZManaged.makeEffect {
+    val tmpFile = File.createTempFile("ZTestRunnerSpec-", ".tmp")
+    val writer = new java.io.PrintWriter(tmpFile)
+    try {
+      writer.print(
+        s"""-testClassTerm
+           |class
+           |-testMethodTerm
+           |method
+           |""".stripMargin
+      )
+    } finally writer.close()
+    tmpFile
+  } { tmpFile => tmpFile.delete() }.toLayer
+
+  override def spec: ZSpec[zio.test.environment.TestEnvironment, Any] = suite("ZTestRunnerSpec")(
+    testM("read arguments from file if command line argument is a file path") {
+      (for {
+        argFile <- ZIO.access[Has[File]](_.get)
+        args <- UIO(ZTestRunner.Args.readArgsFromFileIfCommandLineShortenerIsEnabled(Array(s"@${argFile.getAbsolutePath}")).get)
+      } yield assert(args.toList)(hasSize(equalTo(4)))).provideLayer(tempArgFile)
+    },
+    test("ignore non-file command line argument"){
+      assert(ZTestRunner.Args.readArgsFromFileIfCommandLineShortenerIsEnabled(Array("abc", "efg")))(isNone)
+    }
+  )
+}


### PR DESCRIPTION
When command line arguments for a test runner is too long, they are passed via a temporary file and its path is passed via the command line argument. This commit reads command line arguments from a file if necessary.

patch for this issue.

https://github.com/zio/zio-intellij/issues/39