### PR TITLE
Supporting showing duration of the tests in the runner

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.7
+sbt.version = 1.3.8

--- a/src/shared/src/main/scala/zio/intellij/testsupport/TestRunnerAspects.scala
+++ b/src/shared/src/main/scala/zio/intellij/testsupport/TestRunnerAspects.scala
@@ -1,0 +1,48 @@
+package zio.intellij.testsupport
+
+import zio.ZIO
+import zio.duration.Duration
+import zio.test.TestAnnotationRenderer.LeafRenderer
+import zio.test._
+import zio.test.environment.Live
+
+private[testsupport] object TestRunnerAspects {
+
+  /**
+   * Annotates tests with their execution times.
+   */
+  val timedReport: TestAspectAtLeastR[Live with Annotations] =
+    new TestAspect.PerTest.AtLeastR[Live with Annotations] {
+      def perTest[R <: Live with Annotations, E](
+        test: ZIO[R, TestFailure[E], TestSuccess]
+      ): ZIO[R, TestFailure[E], TestSuccess] =
+        Live.withLive(test)(_.either.timed).flatMap {
+          case (duration, result) =>
+            ZIO.fromEither(result) <*
+              Annotations.get(TestAnnotation.timing).flatMap { current =>
+                val actualDuration = if (current.isZero) duration else current
+                Annotations.annotate(timingTestReport, actualDuration)
+              }
+        }
+    }
+
+  /**
+   * An annotation for timing the test suite (note: this is different from the 'timing' annotation
+   * to prevent clashing)
+   */
+  private val timingTestReport: TestAnnotation[Duration] =
+    TestAnnotation("intellij-timing", Duration.Zero, _ + _)
+
+  /**
+   * A test annotation renderer that renders the time taken to execute each
+   * test or suite both in absolute duration and as a percentage of total
+   * execution time.
+   */
+  val renderTiming: TestAnnotationRenderer =
+    LeafRenderer(timingTestReport) {
+      case child :: _ =>
+        if (child.isZero) None
+        else Some(s"${child.toMillis}")
+    }
+
+}

--- a/src/shared/test/scala/zio/intellij/testsupport/ZTestRunnerSpec.scala
+++ b/src/shared/test/scala/zio/intellij/testsupport/ZTestRunnerSpec.scala
@@ -27,11 +27,11 @@ object ZTestRunnerSpec extends DefaultRunnableSpec {
     testM("read arguments from file if command line argument is a file path") {
       (for {
         argFile <- ZIO.access[Has[File]](_.get)
-        args <- UIO(ZTestRunner.Args.readArgsFromFileIfCommandLineShortenerIsEnabled(Array(s"@${argFile.getAbsolutePath}")).get)
+        args <- UIO(ZTestRunner.Args.readFromFile(Array(s"@${argFile.getAbsolutePath}")).get)
       } yield assert(args.toList)(hasSize(equalTo(4)))).provideLayer(tempArgFile)
     },
     test("ignore non-file command line argument"){
-      assert(ZTestRunner.Args.readArgsFromFileIfCommandLineShortenerIsEnabled(Array("abc", "efg")))(isNone)
+      assert(ZTestRunner.Args.readFromFile(Array("abc", "efg")))(isNone)
     }
   )
 }


### PR DESCRIPTION
Accomplished by using a custom test aspect that provides timing information, or retrieves the timing from the test, it was annotated with the `timed` aspect.